### PR TITLE
Add Biopragmatics registry

### DIFF
--- a/mapping-server.yml
+++ b/mapping-server.yml
@@ -11,3 +11,5 @@ registries:
     uri: https://gitlab.c-path.org/c-pathontology/mapping-commons/-/raw/main/registry.yml
   - id: mesh-mappings
     uri: https://raw.githubusercontent.com/mapping-commons/mesh-mappings/main/mappings.yml
+  - id: biomappings
+    uri: https://github.com/biopragmatics/biomappings/raw/refs/heads/main/registry.yml

--- a/mapping-server.yml
+++ b/mapping-server.yml
@@ -11,5 +11,5 @@ registries:
     uri: https://gitlab.c-path.org/c-pathontology/mapping-commons/-/raw/main/registry.yml
   - id: mesh-mappings
     uri: https://raw.githubusercontent.com/mapping-commons/mesh-mappings/main/mappings.yml
-  - id: biomappings
-    uri: https://github.com/biopragmatics/biomappings/raw/refs/heads/main/registry.yml
+  - id: biopragmatics
+    uri: https://github.com/biopragmatics/mapping-registry/raw/refs/heads/main/registry.yml


### PR DESCRIPTION
This PR adds a new mapping registry for Biopragmatics. It's version controlled repository is https://github.com/biopragmatics/mapping-registry/. The registry file can be found at https://github.com/biopragmatics/mapping-registry/raw/refs/heads/main/registry.yml.

It contains:

- a first-party registry describing the content in Biomappings
- inter-registry mappings from the Bioregistry
- large-scale raw mapping assembly from SeMRA
- domain-specific mapping assemblies from SeMRA

Related, I also asked for upstream fixes in Monarch's version of Biomappings in https://github.com/monarch-initiative/monarch-mapping-commons/issues/72